### PR TITLE
Update current-realm.html test

### DIFF
--- a/WebIDL/current-realm.html
+++ b/WebIDL/current-realm.html
@@ -134,6 +134,9 @@
    test(function() {
      var c = new self[0].FontFace("test", "about:blank"),
          obj = c.load()
+     obj.catch(function(reason) {
+       // Ignore exception when it fails to load because the URL is invalid.
+     });
      assert_global(obj)
 
      obj = FontFace.prototype.load.call(c)


### PR DESCRIPTION
Update current-realm.html test to ignore errors when loading the FontFace from about:blank since it's not a valid URL and the result of the load is not important for the test.